### PR TITLE
fix(UI): mail-list hover

### DIFF
--- a/catppuccin.user.css
+++ b/catppuccin.user.css
@@ -248,4 +248,10 @@
     .ui-prominent, .ui-standard, :root {
       --favorite-icon-color: var(--optional-favorite-icon-color,$peach);
     }
+
+    .item-container-row:hover, .item-container:hover {
+      box-shadow: none;
+      background-color: var(--navigation-current-item-background-color);
+    }
+
 }


### PR DESCRIPTION
Use the same hover effect for the email list that is used in the sidebar navigation.
Before and after screenshots:

<img width="300" alt="before" src="https://user-images.githubusercontent.com/35840154/227520354-9e0cef5f-3c80-49b5-beb9-c2238a2368bd.png"> <img width="300" alt="after" src="https://user-images.githubusercontent.com/35840154/227520364-c5bb7d51-7b3f-46c2-898a-57b28da140f4.png">
